### PR TITLE
 Allow ITutorialService to start a tutorial only by using page as args

### DIFF
--- a/Maui.TutorialCoachMark/Abstractions/ITutorialService.cs
+++ b/Maui.TutorialCoachMark/Abstractions/ITutorialService.cs
@@ -3,5 +3,5 @@ namespace Maui.TutorialCoachMark;
 
 public interface ITutorialService
 {
-    Task ShowTutorialAsync(IList<View> coachMarkViews);
+    Task ShowTutorialAsync(Page parent);
 }

--- a/Maui.TutorialCoachMark/Binding/TutorialBinding.cs
+++ b/Maui.TutorialCoachMark/Binding/TutorialBinding.cs
@@ -66,7 +66,7 @@ public static class Tutorial
         return new BeatAnimation(500, null);
     }
 
-    
+
     #endregion
 
     #region EnableTutorial
@@ -152,6 +152,9 @@ public static class Tutorial
 
     #endregion
 
+    internal static List<View> GetCoachMarksForPage(Page page) =>
+        _tutorialMap.ContainsKey(page) ? _tutorialMap[page] : new List<View>(0);
+
     private static async void OnPageAppearing(object? sender, EventArgs e)
     {
         if (sender is not Page page)
@@ -165,5 +168,4 @@ public static class Tutorial
         await TutorialService.Instance.ShowTutorialAsync(coachMarkViews);
         page.Appearing -= OnPageAppearing;
     }
-
 }

--- a/Maui.TutorialCoachMark/Services/TutorialService.cs
+++ b/Maui.TutorialCoachMark/Services/TutorialService.cs
@@ -5,7 +5,7 @@ namespace Maui.TutorialCoachMark;
 
 internal class TutorialService : ITutorialService
 {
-    public static ITutorialService Instance
+    public static TutorialService Instance
     {
         get; private set;
     }
@@ -15,7 +15,13 @@ internal class TutorialService : ITutorialService
         Instance = this;
     }
 
-    public async Task ShowTutorialAsync(IList<View> coachMarkViews)
+    public Task ShowTutorialAsync(Page parent)
+    {
+        var coachMarkViews = Tutorial.GetCoachMarksForPage(parent);
+        return ShowTutorialAsync(coachMarkViews);
+    }
+
+    internal async Task ShowTutorialAsync(IList<View> coachMarkViews)
     {
         var instance = MopupService.Instance;
         var currentTutorialPage = instance.PopupStack.FirstOrDefault(p => p.GetType() == typeof(TutorialPage));


### PR DESCRIPTION
### Overview

Allow ITutorialService to start a tutorial only by using page as args


### API Changes

- ITutorialService.ShowTutorialAsync(Page);

### Platforms Affected
- All

### Behavioral Changes

Now we can call `ShowTutorialAsync` from codebehind. 
Example:

```csharp
private readonly ITutorialService _tutorialService;
...
public MyPage(ITutorialService tutorialService)
{
    InitializaComponent();
    _tutorialService = tutorialService;
}

protected override void OnAppearing()
{
....
    _tutorialService.ShowTutorialAsync(this);
....
}

```

### Testing Procedure
None

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard