### PR TITLE
Removed the need to use xaml namespace

### DIFF
--- a/Maui.TutorialCoachMark.Sample/MainPage.xaml
+++ b/Maui.TutorialCoachMark.Sample/MainPage.xaml
@@ -3,9 +3,8 @@
     x:Class="Maui.TutorialCoachMark.Sample.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:t="clr-namespace:Maui.TutorialCoachMark;assembly=Maui.TutorialCoachMark"
     x:Name="page"
-    t:Tutorial.EnableTutorial="true">
+    Tutorial.EnableTutorial="true">
 
     <ScrollView>
         <VerticalStackLayout Padding="30,0" Spacing="25">
@@ -16,29 +15,29 @@
                 Source="dotnet_bot.png" />
 
             <Label
-                t:Tutorial.TutorialOrder="1"
-                t:Tutorial.TutorialParent="{Reference page}"
                 SemanticProperties.HeadingLevel="Level1"
                 Style="{StaticResource Headline}"
-                Text="Hello, World!">
-                <t:Tutorial.CoachMarkView>
+                Text="Hello, World!"
+                Tutorial.TutorialOrder="1"
+                Tutorial.TutorialParent="{Reference page}">
+                <Tutorial.CoachMarkView>
                     <StackLayout>
                         <Label
                             FontAttributes="Bold"
                             Text="Describe your elements!"
                             TextColor="White" />
                     </StackLayout>
-                </t:Tutorial.CoachMarkView>
+                </Tutorial.CoachMarkView>
             </Label>
 
             <Label
-                t:Tutorial.TutorialOrder="3"
-                t:Tutorial.TutorialParent="{Reference page}"
                 SemanticProperties.Description="Welcome to dot net Multi platform App U I"
                 SemanticProperties.HeadingLevel="Level2"
                 Style="{StaticResource SubHeadline}"
-                Text="Welcome to &#10;.NET Multi-platform App UI">
-                <t:Tutorial.CoachMarkView>
+                Text="Welcome to &#10;.NET Multi-platform App UI"
+                Tutorial.TutorialOrder="3"
+                Tutorial.TutorialParent="{Reference page}">
+                <Tutorial.CoachMarkView>
                     <Frame
                         BackgroundColor="BlueViolet"
                         CornerRadius="16"
@@ -49,19 +48,19 @@
                             <Label Text="🤩💕" />
                         </StackLayout>
                     </Frame>
-                </t:Tutorial.CoachMarkView>
+                </Tutorial.CoachMarkView>
             </Label>
 
             <Button
                 x:Name="CounterBtn"
-                t:Tutorial.TutorialOrder="2"
-                t:Tutorial.TutorialParent="{Reference page}"
-                t:Tutorial.ViewAnimation="{t:DefaultAnimation Fade}"
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Fill"
                 SemanticProperties.Hint="Counts the number of times you click"
-                Text="Click me">
-                <t:Tutorial.CoachMarkView>
+                Text="Click me"
+                Tutorial.TutorialOrder="2"
+                Tutorial.TutorialParent="{Reference page}"
+                Tutorial.ViewAnimation="{DefaultAnimation Fade}">
+                <Tutorial.CoachMarkView>
                     <Frame
                         BackgroundColor="Black"
                         CornerRadius="16"
@@ -71,9 +70,8 @@
                             <Label Text="Explain about your UI" TextColor="White" />
                         </StackLayout>
                     </Frame>
-                </t:Tutorial.CoachMarkView>
+                </Tutorial.CoachMarkView>
             </Button>
-
         </VerticalStackLayout>
     </ScrollView>
 

--- a/Maui.TutorialCoachMark/Properties/AssemblyInfo.cs
+++ b/Maui.TutorialCoachMark/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+﻿using XmlnsPrefixAttribute = Microsoft.Maui.Controls.XmlnsPrefixAttribute;
+
+//Custom xaml schema <see href="https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-namespace-schemas#defining-a-custom-namespace-schema"/>
+[assembly: XmlnsDefinition("http://schemas.microsoft.com/dotnet/2021/maui", "Maui.TutorialCoachMark")]
+[assembly: XmlnsDefinition("http://neocontrols.com/schemas/xaml", "Maui.TutorialCoachMark")]
+
+//Recommended prefix <see href="https://docs.microsoft.com/pt-br/xamarin/xamarin-forms/xaml/custom-prefix"/>
+[assembly: XmlnsPrefix("http://Maui.TutorialCoachMark.com/schemas/xaml", "tutorial")]

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ public static class MauiProgram
     x:Class="Maui.TutorialCoachMark.Sample.MainPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:t="clr-namespace:Maui.TutorialCoachMark;assembly=Maui.TutorialCoachMark"
     x:Name="page"
-    t:Tutorial.EnableTutorial="true">
+    Tutorial.EnableTutorial="true">
 
     <ScrollView>
         <VerticalStackLayout Padding="30,0" Spacing="25">
@@ -58,17 +57,17 @@ public static class MauiProgram
                 Source="dotnet_bot.png" />
 
             <Label
-                t:Tutorial.TutorialOrder="1"
-                t:Tutorial.TutorialParent="{Reference page}"
+                Tutorial.TutorialOrder="1"
+                Tutorial.TutorialParent="{Reference page}"
                 Text="Hello, World!">
-                <t:Tutorial.CoachMarkView>
+                <Tutorial.CoachMarkView>
                     <StackLayout>
                         <Label
                             FontAttributes="Bold"
                             Text="Describe your elements!"
                             TextColor="White" />
                     </StackLayout>
-                </t:Tutorial.CoachMarkView>
+                </Tutorial.CoachMarkView>
             </Label>
     </ScrollView>
 </ContentPage>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.0.3-pre",
+  "version": "0.0.4-pre",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
### Overview

Removed the need to use xaml namespace

### Issues Resolved

None

### API Changes

All xaml element

### Platforms Affected
- All

### Behavioral Changes
Now we can use the xaml attached properties without declare xaml namespace

### Testing Procedure
Just use the TutorialCoachMark properties without xaml namespace prefix

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard